### PR TITLE
Fix layout issues on mobile

### DIFF
--- a/firebase/src/components/general/appHeader.tsx
+++ b/firebase/src/components/general/appHeader.tsx
@@ -66,7 +66,7 @@ export function AppHeader() {
                     </IconLink>
                     <IconLink to={NavUtils.getNavUrl[Page.Rendelo]()}>
                         <Button color="inherit" size="small">
-                            Háziorvosoknak/rendelőknek
+                            Háziorvosoknak / rendelőknek
                         </Button>
                     </IconLink>
                 </AppIcons>
@@ -150,7 +150,14 @@ const AppTitleLink = styled(Link)`
 `;
 
 const AppIcons = styled.div`
-    flex-grow: 1;
+    ${({ theme }) => `
+        flex-grow: 1;
+        ${theme.breakpoints.down("xs")} {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+    `}
 `;
 
 const IconLink = styled(Link)`

--- a/firebase/src/components/surgeryPage/surgeryPageLoggedIn.tsx
+++ b/firebase/src/components/surgeryPage/surgeryPageLoggedIn.tsx
@@ -1,6 +1,7 @@
 import {
     Grid, Typography,
 } from "@material-ui/core";
+import styled from "styled-components/macro";
 import { CollectionId, IFirestoreSurgeryPrivate } from "@mikoroltanak/api";
 import * as React from "react";
 import { useFirestoreDocSubscription } from "../data-loaders/useFirestoreSubscription";
@@ -17,10 +18,19 @@ export function SurgeryPageLoggedIn({ surgeryId }: { surgeryId: string }) {
     return (
         <Grid container spacing={5} direction="column" alignItems="center">
             <Grid item xs={12} md={6}>
-                <Typography variant="h2" align="center" gutterBottom>Háziorvosoknak/rendelőknek</Typography>
+                <Title variant="h2" align="center" gutterBottom>Háziorvosoknak / rendelőknek</Title>
             </Grid>
             <SurgeryPagePublicInfo surgeryId={surgeryId} />
             {surgeryPrivate && <SurgeryPagePrivateInfo surgeryId={surgeryId} surgeryPrivate={surgeryPrivate} />}
         </Grid>
     );
 }
+
+// Styles
+const Title = styled(Typography)`
+    ${({ theme }) => `
+        ${theme.breakpoints.down("xs")} {
+            font-size: 2rem;
+        }
+    `}
+`;

--- a/firebase/src/components/surgeryPage/surgeryPageNotLoggedIn.tsx
+++ b/firebase/src/components/surgeryPage/surgeryPageNotLoggedIn.tsx
@@ -2,6 +2,7 @@ import {
     Button,
     Grid, Typography,
 } from "@material-ui/core";
+import styled from "styled-components/macro";
 import * as React from "react";
 import { NavUtils, Page } from "../../utils/navUtils";
 import { Login } from "../general/login";
@@ -10,7 +11,7 @@ export function SurgeryPageNotLoggedIn() {
     return (
         <Grid container spacing={5} direction="column" alignItems="center">
             <Grid item xs={12} md={6}>
-                <Typography variant="h2" align="center" gutterBottom>Háziorvosoknak/rendelőknek</Typography>
+                <Title variant="h2" align="center" gutterBottom>Háziorvosoknak / rendelőknek</Title>
             </Grid>
             <Grid item xs={12} md={6} container direction="column" alignItems="stretch">
                 <Typography variant="body1" paragraph>
@@ -43,3 +44,12 @@ export function SurgeryPageNotLoggedIn() {
         </Grid>
     );
 }
+
+// Styles
+const Title = styled(Typography)`
+    ${({ theme }) => `
+        ${theme.breakpoints.down("xs")} {
+            font-size: 2rem;
+        }
+    `}
+`;


### PR DESCRIPTION
Some buttons (in the `appHeader`) and titles (in `surgeryPageXXX`) broke the layout on mobile.
Only changed the layout below `xs`.

Before:
![before1](https://user-images.githubusercontent.com/1479192/110363713-2eb96c00-8043-11eb-9eea-256a54654aac.png)
![before2](https://user-images.githubusercontent.com/1479192/110363718-2fea9900-8043-11eb-9f4d-be2b10267a7d.png)

After:
![after](https://user-images.githubusercontent.com/1479192/110363748-3842d400-8043-11eb-9c3c-63b39f1940a8.png)
