### PR TITLE
Fix MainAppBar layout under 600px

### DIFF
--- a/firebase/src/components/general/appHeader.tsx
+++ b/firebase/src/components/general/appHeader.tsx
@@ -66,7 +66,7 @@ export function AppHeader() {
 
     return (
         <MainAppBar position="static" elevation={0}>
-            <Toolbar>
+            <AppToolBar>
                 <AppTitle variant="h6">
                     <AppTitleLink to={NavUtils.getNavUrl[Page.Kezdolap]()}>
                         Mikor oltanak?
@@ -182,7 +182,7 @@ export function AppHeader() {
                         style={{ backgroundColor: green[700] }}
                     />
                 </Snackbar>
-            </Toolbar>
+            </AppToolBar>
         </MainAppBar>
     );
 }
@@ -192,8 +192,26 @@ const MainAppBar = styled(AppBar)`
     padding: ${({ theme }) => theme.spacing(0, 5)};
 `;
 
+const AppToolBar = styled(Toolbar)`
+    ${({ theme }) => `
+        ${theme.breakpoints.down("xs")} {
+            flex-wrap: wrap;
+            flex: 1 0 50%;
+            padding: 10px 0;
+        }
+    `})}
+`;
+
 const AppTitle = styled(Typography)`
     margin-right: ${({ theme }) => theme.spacing(10)};
+    ${({ theme }) =>`
+        ${theme.breakpoints.down("xs")} {
+            margin-right: 0;
+            flex-basis: 100%;
+            text-align: center;
+            font-size: 2rem;
+        }
+    `}
 `;
 
 const AppTitleLink = styled(Link)`
@@ -207,6 +225,8 @@ const AppIcons = styled.div`
             display: flex;
             flex-direction: column;
             align-items: center;
+            flex-basis: 100%;
+            margin-bottom: 15px;
         }
     `}
 `;
@@ -219,8 +239,21 @@ const IconLink = styled(Link)`
 
 const ShareButtonContainer = styled.div`
     margin-right: 1rem;
+
+    ${({ theme }) =>`
+        ${theme.breakpoints.down("xs")} {
+            margin-right: 0;
+            margin-left: auto;
+        }
+    `}
 `;
 
 const MomentumButtonContainer = styled.div`
     margin-right: 1rem;
+
+    ${({ theme }) =>`
+        ${theme.breakpoints.down("xs")} {
+            margin-right: 0;
+        }
+    `}
 `;


### PR DESCRIPTION
A header borzasztóan szétesett mobil nézetben. Ez csak egy gyors fix javaslat. Hosszú távon szerintem egy hamburger menü implementálása lehetne megnyugtatóbb megoldás.
Előtte:
<img width="365" alt="image" src="https://user-images.githubusercontent.com/25322572/111844997-5393c600-8904-11eb-8cfc-f4a1b561e3c7.png">
Utána:
<img width="364" alt="image" src="https://user-images.githubusercontent.com/25322572/111845176-a1a8c980-8904-11eb-97d4-3015a82fea53.png">

